### PR TITLE
Use curl instead of Wget for better compatability with Microsoft Windows 10 1803 and above

### DIFF
--- a/Assignments/Practical/PracticalNotebook2.ipynb
+++ b/Assignments/Practical/PracticalNotebook2.ipynb
@@ -317,7 +317,7 @@
    "outputs": [],
    "source": [
     "# Downloading the titanic dataset\n",
-    "!wget https://web.stanford.edu/class/archive/cs/cs109/cs109.1166/stuff/titanic.csv"
+    "!curl https://web.stanford.edu/class/archive/cs/cs109/cs109.1166/stuff/titanic.csv -o titanic.csv"
    ]
   },
   {
@@ -816,7 +816,7 @@
    "outputs": [],
    "source": [
     "# Downloading the titanic dataset\n",
-    "!wget https://web.stanford.edu/class/archive/cs/cs109/cs109.1166/stuff/titanic.csv"
+    "!curl https://web.stanford.edu/class/archive/cs/cs109/cs109.1166/stuff/titanic.csv -o titanic.csv"
    ]
   },
   {


### PR DESCRIPTION
For people using Windows (10 build 1803 or later, or 11), it would be beneficial to use use curl for downloading the CSV data in practical assignment 2. The Wget tool is not present on a default installation of Windows. curl is still as ubiquitous, if not more, than Wget on Linux and macOS as well.