### PR TITLE
Improve dependency version compatability checking for theoretical assignment 2

### DIFF
--- a/Assignments/Theoretical/theoretical2.ipynb
+++ b/Assignments/Theoretical/theoretical2.ipynb
@@ -65,9 +65,20 @@
    },
    "outputs": [],
    "source": [
-    "assert np.__version__ == \"2.2.0\", \"Looks like you don't have the same version of numpy as us!\"\n",
-    "assert mpl.__version__ == \"3.10.0\", \"Looks like you don't have the same version of matplotlib as us!\"\n",
-    "assert sklearn.__version__ == \"1.6.0\", \"Looks like you don't have the same version of sklearn as us!\""
+    "# version compatability checking\n",
+    "from packaging import version\n",
+    "\n",
+    "def check_version(module, expected_version):\n",
+    "    current_version = version.parse(module.__version__)\n",
+    "    expected_version = version.parse(expected_version)\n",
+    "\n",
+    "    assert (\n",
+    "        current_version.major == expected_version.major and current_version >= expected_version\n",
+    "    ), f\"Looks like you don't have the correct version of {module.__name__}! Expected {expected_version}, but got {current_version}.\"\n",
+    "\n",
+    "check_version(np, \"2.2.0\")\n",
+    "check_version(mpl, \"3.10.0\")\n",
+    "check_version(sklearn, \"1.6.0\")"
    ]
   },
   {


### PR DESCRIPTION
If the users dependency is of a the same or a newer version than the required one, and of the same major version, then they should be API compatible according to semantic versioning.