### PR TITLE
Fix Jupyter nbconvert to latex bug with math mode for theorerical assignment 2

### DIFF
--- a/Assignments/Theoretical/theoretical2.ipynb
+++ b/Assignments/Theoretical/theoretical2.ipynb
@@ -271,8 +271,8 @@
     "**The full algorithm is:**\n",
     "1. Initialize the weights randomly. \n",
     "2. Calculate the gradients of cost function w.r.t parameters.\n",
-    "3. Update the weights by $ \\theta_j \\leftarrow \\theta_j - \\alpha \\frac{\\partial}{\\partial\\theta_j}J(\\theta). $\n",
-    "4. Update the bias by $ \\theta_0 \\leftarrow \\theta_0 - \\alpha \\frac{\\partial}{\\partial \\theta_0}J(\\theta). $\n",
+    "3. Update the weights by $\\theta_j \\leftarrow \\theta_j - \\alpha \\frac{\\partial}{\\partial\\theta_j}J(\\theta).$\n",
+    "4. Update the bias by $\\theta_0 \\leftarrow \\theta_0 - \\alpha \\frac{\\partial}{\\partial \\theta_0}J(\\theta).$\n",
     "5. Repeat until value of cost function does not change or to a pre-defined number of iterations."
    ]
   },


### PR DESCRIPTION
For some reason, converting the Playbook to latex with Jupyter nbconvert seems to make the Latex compile fail then there is leading or trailing white space in the inline math mode of these two lines. After these modifications, I can successfully render a PDF.